### PR TITLE
Add JustCause as a toolbox for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please cite [our survey paper](https://arxiv.org/pdf/1809.09337) if this index i
 |[TETRAD toolbox](http://www.phil.cmu.edu/tetrad/about.html)|[Ramsey, Joseph D., Kun Zhang, Madelyn Glymour, Ruben Sanchez Romero, Biwei Huang, Imme Ebert-Uphoff, Savini Samarasinghe, Elizabeth A. Barnes, and Clark Glymour. "TETRAD-AToolbox FOR CAUSAL DISCOVERY."](https://www.atmos.colostate.edu/~iebert/PAPERS/CI2018_paper_35.pdf)|[R](https://github.com/bd2kccd/r-causal)|
 |CausalDiscoveryToolbox|[Kalainathan, Diviyan, and Olivier Goudet. "Causal Discovery Toolbox: Uncover causal relationships in Python." arXiv preprint arXiv:1903.02278 (2019).](https://arxiv.org/pdf/1903.02278)|[Python](https://github.com/Diviyan-Kalainathan/CausalDiscoveryToolbox)|
 |Uber CausalML|NA|[Python](https://github.com/uber/causalml)|
+|JustCause|For evaluation of heterogeneous treatment effect estimators on common reference as well as synthetic data. [Underlying thesis](https://justcause.readthedocs.io/en/latest/_downloads/e054f7a0fc9cf9e680173600cb4b4350/thesis-mfranz.pdf)|[Python](https://github.com/inovex/justcause)|
 
 ## Learning Causal Effects
 
@@ -240,4 +241,5 @@ Please cite [our survey paper](https://arxiv.org/pdf/1809.09337) if this index i
 |Causal PSL|Sridhar, Dhanya, Jay Pujara, and Lise Getoor. "Scalable Probabilistic Causal Structure Discovery." In IJCAI, pp. 5112-5118. 2018.|[Java](https://bitbucket.org/linqs/causpsl)|
 
 ### Learning Causal Relationships with non-i.i.d. Data
+
 


### PR DESCRIPTION
Proposing to add [JustCause](https://justcause.readthedocs.io/en/latest/) to the list of toolboxes in my own interest as a co-author. 

JustCause aims to simplify and standardise the evaluation of causal effect estimation methods, which I found in my thesis to be an error prone and non-trivial task given the importance of the underlying data generating processes. 

JustCause: 

- Provides common reference datasets (IHDP, Twins, ACIC challenge) in an accessible way 
- Provides a method for generating synthetic data from a standardised terminology 
- Provides basic learners and methods. 

In the future we hope to add more learners as well as further datasets and are looking for contributions from researchers. 
 