### PR TITLE
Add WhyNot to toolboxes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please cite [our survey paper](https://arxiv.org/pdf/1809.09337) if this index i
 |CausalDiscoveryToolbox|[Kalainathan, Diviyan, and Olivier Goudet. "Causal Discovery Toolbox: Uncover causal relationships in Python." arXiv preprint arXiv:1903.02278 (2019).](https://arxiv.org/pdf/1903.02278)|[Python](https://github.com/Diviyan-Kalainathan/CausalDiscoveryToolbox)|
 |Uber CausalML|NA|[Python](https://github.com/uber/causalml)|
 |JustCause|For evaluation of heterogeneous treatment effect estimators on common reference as well as synthetic data. [Underlying thesis](https://justcause.readthedocs.io/en/latest/_downloads/e054f7a0fc9cf9e680173600cb4b4350/thesis-mfranz.pdf)|[Python](https://github.com/inovex/justcause)|
+|WhyNot|An experimental sandbox for causal inference and decision making in dynamics. [Documentation](https://whynot.readthedocs.io/en/latest/)|[Python](https://github.com/zykls/whynot)|
 
 ## Learning Causal Effects
 


### PR DESCRIPTION
Thanks for creating this wonderful resource!

I'd like to add a recently developed package [WhyNot](https://github.com/zykls/whynot) to the set of toolboxes. In essence, WhyNot is an experimental sandbox testing and experimenting with causal inference and decision making in dynamics.

WhyNot allows researchers to use data from sophisticated computer simulations to develop, test, and benchmark methods for causal inference and reinforcement learning. 

WhyNot provides:
- A diverse set of complex [simulated environments](https://whynot.readthedocs.io/en/latest/simulators.html#simulators)
- A suite of state-of-the-art [causal inference methods](https://whynot.readthedocs.io/en/latest/estimators.html#estimators)
- An extensive collection of [experimental examples](https://whynot.readthedocs.io/en/latest/examples.html#experiment-examples)
- An extensible, easy-to-use framework that makes it easy to add more experiments, estimators, and simulators.

Looking forward to sharing WhyNot with the community!